### PR TITLE
"editorGutter.background" を #1e1e1e→#151515に変更

### DIFF
--- a/themes/111-theme.json
+++ b/themes/111-theme.json
@@ -1960,7 +1960,7 @@
         "editorInfo.foreground": "#75beff",
         "editorInfo.background": "#4490BF00",
         "editorInfo.border": "#4490BF00",
-        "editorGutter.background": "#1e1e1e",
+        "editorGutter.background": "#151515",
         "editorGutter.modifiedBackground": "#0c7d9d",
         "editorGutter.addedBackground": "#587c0c",
         "editorGutter.deletedBackground": "#94151b",


### PR DESCRIPTION
## PR概要
現在 editorGutter.background（行番号エリアの背景色）が #1e1e1e となっていますが、
これを #151515 に変更しました。

## 変更理由
デザイン上、背景色が画面上で目立ちすぎていると感じたため、調整しました。

## 変更内容
- themes/111-theme.json L1963
    - `#1e1e1e` → `#151515`

## 影響範囲
行番号エリアの背景色にのみ影響があります。

## 備考
本PRは Issue No. #1 の実装です。